### PR TITLE
Fix nav active section not updating on scroll

### DIFF
--- a/lib/hooks.ts
+++ b/lib/hooks.ts
@@ -3,9 +3,13 @@ import { useEffect } from "react";
 import { useInView } from "react-intersection-observer";
 import type { SectionName } from "./types";
 
-export function useSectionInView(sectionName: SectionName, threshold = 0.75) {
+export function useSectionInView(sectionName: SectionName, _threshold = 0.75) {
+  // Track which section crosses the vertical center of the viewport. This works
+  // regardless of section height, unlike a visibility threshold which never
+  // fires for sections taller than the viewport.
   const { ref, inView } = useInView({
-    threshold,
+    threshold: 0,
+    rootMargin: "-50% 0px -50% 0px",
   });
   const { setActiveSection, timeOfLastClick } = useActiveSectionContext();
 


### PR DESCRIPTION
useSectionInView required 75% visibility, which sections taller than the viewport never reach, so the nav highlight got stuck. Switch to a viewport center-line band (rootMargin -50% 0px -50% 0px, threshold 0) so exactly one section is active regardless of height. Click-to-jump guard preserved.